### PR TITLE
Add benchmarks for different numbers of columns

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -45,9 +45,9 @@ version = "0.4.2"
 
 [[CSVFiles]]
 deps = ["DataValues", "FileIO", "HTTP", "IterableTables", "IteratorInterfaceExtensions", "TableShowUtils", "TableTraits", "TableTraitsUtils", "Test", "TextParse"]
-git-tree-sha1 = "b39c9d94d944ab5c7ee9d7503509a63ea21d564c"
+git-tree-sha1 = "7f38660b77f759d40f3f272d69aae0a8da0b7695"
 uuid = "5d742f6a-9f54-50ce-8119-2520741973ca"
-version = "0.9.1"
+version = "0.10.0"
 
 [[Cairo]]
 deps = ["BinDeps", "Colors", "Compat", "Graphics", "Homebrew", "Libdl", "Pkg", "WinRPM"]
@@ -147,9 +147,9 @@ version = "0.19.6"
 
 [[DoubleFloats]]
 deps = ["AccurateArithmetic", "LinearAlgebra", "Pkg", "Polynomials", "Random", "Test", "Unicode"]
-git-tree-sha1 = "5d39473509e121653134cb97b76527f6b8355f4d"
+git-tree-sha1 = "a4b04174f3b863a320d80415091804bc90db585e"
 uuid = "497a8b3b-efae-58df-a0af-a86822472b78"
-version = "0.3.0"
+version = "0.3.1"
 
 [[Electron]]
 deps = ["Base64", "JSON", "Pkg", "Sockets", "Test", "URIParser"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,11 @@
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
+CSVFiles = "5d742f6a-9f54-50ce-8119-2520741973ca"
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Pandas = "eadc2687-ae89-51f9-a5d9-86b5a6373a9c"
+Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Queryverse = "612083be-0b0f-5412-89c1-4e7c75506a58"
 RCall = "6f49c342-dc21-5d91-9882-a32aef131414"
+Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 TextParse = "e0df1984-e451-5cb5-8b61-797a481e67e3"

--- a/common.jl
+++ b/common.jl
@@ -1,1 +1,6 @@
-ourpath(rows, withna) = joinpath("data", string("rows_", rows, "_na_", withna))
+ourpath(rows, cols, withna) = joinpath("data", string("rows_", rows, "_cols_", cols, "_na_", withna))
+
+const ns = [100, 10_000, 1_000_000];
+const cs = [20, 200, 2000];
+const samples = 5;
+const missing_share = 0.5;

--- a/main.jl
+++ b/main.jl
@@ -5,8 +5,6 @@ using CSV, TextParse, Tables, Printf, RCall, Dates, Queryverse
 import Pandas
 include("common.jl")
 
-const ns = [100, 10_000, 1_000_000];
-const samples = 5;
 const jl06bin = if Sys.iswindows()
     `$(joinpath(homedir(), "AppData", "Local", "Julia-0.6.4", "bin", "julia.exe"))`
 elseif Sys.isapple()
@@ -22,30 +20,30 @@ library(readr)
 options(readr.num_columns = 0)
 """;
 
-function read_specific_file(df, rows, withna, filename, samples)
+function read_specific_file(df, rows, cols, withna, filename, samples)
     filename_for_label = filename
-    filename = joinpath(ourpath(rows, withna), filename)
-    
+    filename = joinpath(ourpath(rows, cols, withna), filename)
+
     t::Float64 = 0.
-        
+
     csvread(filename)
     for i in 1:samples
         GC.gc(); GC.gc(); GC.gc()
-        t = @elapsed csvread(filename)        
-        push!(df, (file=filename_for_label, rows=rows, withna=withna, package="TextParse.jl", sample=i, timing=t))
+        t = @elapsed csvread(filename)
+        push!(df, (file=filename_for_label, rows=rows, cols=cols, withna=withna, package="TextParse.jl", sample=i, timing=t))
     end
 
     DataFrame(load(filename))
     for i in 1:samples
         GC.gc(); GC.gc(); GC.gc()
         t = @elapsed DataFrame(load(filename))
-        push!(df, (file=filename_for_label, rows=rows, withna=withna, package="CSVFiles.jl", sample=i, timing=t))
+        push!(df, (file=filename_for_label, rows=rows, cols=cols, withna=withna, package="CSVFiles.jl", sample=i, timing=t))
     end
 
     try
         ts = parse.(Float64, readlines(`$jl06bin textparsejulia06script.jl $filename $samples`))
         for (i,t) in enumerate(ts)
-            push!(df, (file=filename_for_label, rows=rows, withna=withna, package="TextParse.jl; 0.6", sample=i, timing=t))
+            push!(df, (file=filename_for_label, rows=rows, cols=cols, withna=withna, package="TextParse.jl; 0.6", sample=i, timing=t))
         end
     catch err
         @info err
@@ -54,26 +52,26 @@ function read_specific_file(df, rows, withna, filename, samples)
     try
         ts = parse.(Float64, readlines(`$jl06bin csvjulia06script.jl $filename $samples`))
         for (i,t) in enumerate(ts)
-            push!(df, (file=filename_for_label, rows=rows, withna=withna, package="CSV.jl; 0.6", sample=i, timing=t))
+            push!(df, (file=filename_for_label, rows=rows, cols=cols, withna=withna, package="CSV.jl; 0.6", sample=i, timing=t))
         end
     catch err
         @info err
     end
-    
+
     CSV.File(filename) |> DataFrame
     for i in 1:samples
         GC.gc(); GC.gc(); GC.gc()
         t = @elapsed CSV.File(filename) |> DataFrame
-        push!(df, (file=filename_for_label, rows=rows, withna=withna, package="CSV.jl", sample=i, timing=t))
-    end    
-    
+        push!(df, (file=filename_for_label, rows=rows, cols=cols, withna=withna, package="CSV.jl", sample=i, timing=t))
+    end
+
     Pandas.read_csv(filename)
     for i in 1:samples
         GC.gc(); GC.gc(); GC.gc()
         t = @elapsed Pandas.read_csv(filename)
-        push!(df, (file=filename_for_label, rows=rows, withna=withna, package="Pandas.jl", sample=i, timing=t))
+        push!(df, (file=filename_for_label, rows=rows, cols=cols, withna=withna, package="Pandas.jl", sample=i, timing=t))
     end
-    
+
     R"""
         fread($filename, nThread=1)
     """
@@ -83,11 +81,11 @@ function read_specific_file(df, rows, withna, filename, samples)
             fread($filename, nThread=1)
             end_time = Sys.time()
             elap = end_time - start_time
-            """)    
-        push!(df, (file=filename_for_label, rows=rows, withna=withna, package="R fread", sample=i, timing=t))
+            """)
+        push!(df, (file=filename_for_label, rows=rows, cols=cols, withna=withna, package="R fread", sample=i, timing=t))
     end
-    
-    
+
+
     R"""
         fread($filename, nThread=15)
     """
@@ -97,10 +95,10 @@ function read_specific_file(df, rows, withna, filename, samples)
             fread($filename, nThread=15)
             end_time = Sys.time()
             elap = end_time - start_time
-            """)    
-            push!(df, (file=filename_for_label, rows=rows, withna=withna, package="R fread parallel", sample=i, timing=t))
+            """)
+            push!(df, (file=filename_for_label, rows=rows, cols=cols, withna=withna, package="R fread parallel", sample=i, timing=t))
     end
-        
+
     R"""
         suppressMessages(read_csv($filename, progress = FALSE))
     """
@@ -110,47 +108,49 @@ function read_specific_file(df, rows, withna, filename, samples)
             suppressMessages(read_csv($filename, progress = FALSE))
             end_time = Sys.time()
             elap = end_time - start_time
-            """)    
-            push!(df, (file=filename_for_label, rows=rows, withna=withna, package="R readr", sample=i, timing=t))
-    end    
-    
+            """)
+            push!(df, (file=filename_for_label, rows=rows, cols=cols, withna=withna, package="R readr", sample=i, timing=t))
+    end
+
     nothing
 end
 
-df = DataFrame(file=String[], rows=Int[], withna=Bool[], package=String[], sample=Int[], timing=Float64[])
+df = DataFrame(file=String[], rows=Int[], cols=Int[], withna=Bool[], package=String[], sample=Int[], timing=Float64[])
 
-for n in ns, withna in [true, false]
-    for filename in filter(i->endswith(i, ".csv"), readdir(ourpath(n, withna)))
-        @info "$filename, n=$n, withna=$withna"
-        read_specific_file(df, n, withna, filename, samples)
+for n in ns, c in cs, withna in [true, false]
+    for filename in filter(i->endswith(i, ".csv"), readdir(ourpath(n, c, withna)))
+        @info "$filename, n=$n, c=$c, withna=$withna"
+        read_specific_file(df, n, c, withna, filename, samples)
     end
 end
 
 output_folder_name = joinpath("output", replace("run_$(now())", ":" => "_"))
-mkdir(output_folder_name)
+mkpath(output_folder_name)
 
 df |> save(joinpath(output_folder_name, "timings.csv"))
 
-df |>
-@filter(!_.withna) |>
-@vlplot(facet={row={field=:file, typ=:nominal, title=nothing}, column={field=:rows, typ=:ordinal}}, resolve={scale={x=:independent}}, title="Without missing data", background=:white) +
-    (
-        @vlplot(y={"package:n", title=nothing}, resolve={scale={x=:shared}}) +
-        @vlplot(:bar,  x={"min(timing)", title="seconds"}, color=:package) +
-        @vlplot(:rule, x="min(timing)", x2="max(timing)") +
-        @vlplot(:tick, x=:timing)
-    ) |>
-@tee(save(joinpath(output_folder_name, "withoutna.pdf"))) |>
-save(joinpath(output_folder_name, "withoutna.png"))
+for c in cs
+    df |>
+    @filter(!_.withna && _.cols == c) |>
+    @vlplot(facet={row={field=:file, typ=:nominal, title=nothing}, column={field=:rows, typ=:ordinal}}, resolve={scale={x=:independent}}, title="Without missing data ($c columns)", background=:white) +
+        (
+            @vlplot(y={"package:n", title=nothing}, resolve={scale={x=:shared}}) +
+            @vlplot(:bar,  x={"min(timing)", title="seconds"}, color=:package) +
+            @vlplot(:rule, x="min(timing)", x2="max(timing)") +
+            @vlplot(:tick, x=:timing)
+        ) |>
+    @tee(save(joinpath(output_folder_name, "cols_$(c)_withoutna.pdf"))) |>
+    save(joinpath(output_folder_name, "cols_$(c)_withoutna.png"))
 
-df |>
-@filter(_.withna) |>
-@vlplot(facet={row={field=:file, typ=:nominal, title=nothing}, column={field=:rows, typ=:ordinal}}, resolve={scale={x=:independent}}, title="With missing data", background=:white) +
-    (
-        @vlplot(y={"package:n", title=nothing}, resolve={scale={x=:shared}}) +
-        @vlplot(:bar,  x={"min(timing)", title="seconds"}, color=:package) +
-        @vlplot(:rule, x="min(timing)", x2="max(timing)") +
-        @vlplot(:tick, x=:timing)
-    ) |>
-@tee(save(joinpath(output_folder_name, "withna.pdf"))) |>
-save(joinpath(output_folder_name, "withna.png"))
+    df |>
+    @filter(_.withna && _.cols == c) |>
+    @vlplot(facet={row={field=:file, typ=:nominal, title=nothing}, column={field=:rows, typ=:ordinal}}, resolve={scale={x=:independent}}, title="With missing data ($c columns)", background=:white) +
+        (
+            @vlplot(y={"package:n", title=nothing}, resolve={scale={x=:shared}}) +
+            @vlplot(:bar,  x={"min(timing)", title="seconds"}, color=:package) +
+            @vlplot(:rule, x="min(timing)", x2="max(timing)") +
+            @vlplot(:tick, x=:timing)
+        ) |>
+    @tee(save(joinpath(output_folder_name, "cols_$(c)_withna.pdf"))) |>
+    save(joinpath(output_folder_name, "cols_$(c)_withna.png"))
+end

--- a/writedata.jl
+++ b/writedata.jl
@@ -5,9 +5,6 @@ using DataFrames, CSVFiles, Dates, Printf
 
 include("common.jl")
 
-const ns = [100, 10_000, 1_000_000];
-const missing_share = 0.5
-
 struct ShortFloat64
 end
 
@@ -32,9 +29,9 @@ end
 
 function getrandomcolumn(typ::Type{CatString}, rows, withna)
     n = Int(round(rows * 0.02))
-    
+
     vals = [string("test string ", rand(Int64)) for v in 1:n]
-    
+
     if withna
         return [rand() > (1-missing_share) ? missing : vals[rand(1:n)] for r in 1:rows]
     else
@@ -59,23 +56,26 @@ function getrandomcolumn(typ::Type{DateTime}, rows, withna)
 end
 
 function write_uniform_csv(typ, rows, cols, withna)
-    mkpath(ourpath(rows, withna))
+    mkpath(ourpath(rows, cols, withna))
     filename = string("uniform_data_", lowercase(string(typ)), ".csv")
-    DataFrame([getrandomcolumn(typ, rows, withna) for c in 1:cols], [Symbol("col", c) for c in 1:cols]) |> save(joinpath(ourpath(rows, withna), filename), nastring="")
+    DataFrame([getrandomcolumn(typ, rows, withna) for c in 1:cols], [Symbol("col", c) for c in 1:cols]) |> save(joinpath(ourpath(rows, cols, withna), filename), nastring="")
 end
 
-function write_mixed_csv(rows, filename, types, withna)
-    mkpath(ourpath(rows, withna))
-    DataFrame([getrandomcolumn(typ, rows, withna) for typ in types], [Symbol("col", c) for c in 1:length(types)]) |> save(joinpath(ourpath(rows, withna), filename), nastring="")
+function write_mixed_csv(rows, cols, filename, types, withna)
+    mkpath(ourpath(rows, cols, withna))
+    col_types = Iterators.take(Iterators.cycle(types), cols)
+    DataFrame([getrandomcolumn(typ, rows, withna) for typ in col_types],
+              [Symbol("col", c) for c in 1:cols]) |>
+              save(joinpath(ourpath(rows, cols, withna), filename), nastring="")
 end
 
-for n in ns, withna in [true,false]
-    write_uniform_csv(DateTime, n, 20, withna)
-    write_uniform_csv(String, n, 20, withna)
-    write_uniform_csv(CatString, n, 20, withna)
-    write_uniform_csv(Int64, n, 20, withna)
-    write_uniform_csv(Float64, n, 20, withna)
-    write_uniform_csv(ShortFloat64, n, 20, withna)
-    write_mixed_csv(n, "mixed_data.csv", [Float64, Int64, String, DateTime, CatString], withna)
-    write_mixed_csv(n, "mixed_data_shortfloat64.csv", [ShortFloat64, Int, String, DateTime, CatString], withna)
+for n in ns, c in cs, withna in [true,false]
+    write_uniform_csv(DateTime, n, c, withna)
+    write_uniform_csv(String, n, c, withna)
+    write_uniform_csv(CatString, n, c, withna)
+    write_uniform_csv(Int64, n, c, withna)
+    write_uniform_csv(Float64, n, c, withna)
+    write_uniform_csv(ShortFloat64, n, c, withna)
+    write_mixed_csv(n, c, "mixed_data.csv", [Float64, Int64, String, DateTime, CatString], withna)
+    write_mixed_csv(n, c, "mixed_data_shortfloat64.csv", [ShortFloat64, Int, String, DateTime, CatString], withna)
 end


### PR DESCRIPTION
```writedata.jl``` now generates files over a gradient of column numbers (determined by global const cs, analogous to ns for rows), ```main.jl``` now runs additionally over all cs and generates figures separately for each (it may be possible to incorporate the number of columns into the original figures, for instance as grouped bars per read method).

To make this consistent, the mixed data sets now also feature same cs (generated by cycling over the requested types). I furthermore took the freedom to move all shared benchmark parameters into ```common.jl``` for easier tuning. I tried the whole benchmark with small numbers (ns=[50, 100], cs=[5, 10], samples=2) and everything seems to work.